### PR TITLE
Speed improvement with regards to SINT16 and SINT24

### DIFF
--- a/edf.js
+++ b/edf.js
@@ -8,11 +8,6 @@ function arrayToAscii(array, start, length)
 	return str.trim();
 }
 
-function flipBits(n) 
-{
-  return parseInt(n.toString(2).split('').map(bit => 1 - bit).join(''),2)
-}
-
 class EDF
 {
 	constructor(uint8array)
@@ -157,12 +152,7 @@ class EDF
 						var b1 = buf[pos]; pos++;
 						var b2 = buf[pos]; pos++;						
 											
-						var val = (b2 << 8) + b1;
-			
-						if (b2 >> 7 == 1)
-						{				
-							val = -flipBits(val)-1;	
-						}
+						var val = ((b2 << 24) + (b1 << 16)) >> 16;
 						this.channels[i].data.push(val*koef);
 					}
 					else if (this.bytes_per_sample == 3)
@@ -171,12 +161,7 @@ class EDF
 						var b2 = buf[pos]; pos++;						
 						var b3 = buf[pos]; pos++;						
 											
-						var val = (b3 << 16) + (b2 << 8) + b1;
-			
-						if (b3 >> 7 == 1)
-						{				
-							val = -flipBits(val)-1;	
-						}
+						var val = ((b2 << 24) + (b1 << 16)) >> 16;
 						this.channels[i].data.push(val*koef);
 					}
 				}

--- a/edf.js
+++ b/edf.js
@@ -152,7 +152,7 @@ class EDF
 						var b1 = buf[pos]; pos++;
 						var b2 = buf[pos]; pos++;						
 											
-						var val = ((b2 << 24) + (b1 << 16)) >> 16;
+						var val = ((b2 << 24) | (b1 << 16)) >> 16;
 						this.channels[i].data.push(val*koef);
 					}
 					else if (this.bytes_per_sample == 3)
@@ -161,7 +161,7 @@ class EDF
 						var b2 = buf[pos]; pos++;						
 						var b3 = buf[pos]; pos++;						
 											
-						var val = ((b2 << 24) + (b1 << 16)) >> 16;
+						var val = ((b3 << 24) | (b2 << 16) | (b1 << 8)) >> 8;
 						this.channels[i].data.push(val*koef);
 					}
 				}


### PR DESCRIPTION
Small change to quickly read UINT16 numbers instead of using the flipBits function. Also, you get rid of one conditional statement. In critical loop, it's important. Enjoy!